### PR TITLE
fix project license expression metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = 'A simple optionally-async python inotify library, focused on simp
 version = '4.2.1'
 readme = 'README.rst'
 requires-python = '>= 3.6, < 4'
-license = {text = 'MPL-2.0'}
+license = 'MPL-2.0'
 keywords = [
     'async',
     'inotify',
@@ -15,7 +15,6 @@ classifiers=[
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.6',
     'Operating System :: POSIX :: Linux',
-    'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
     'Topic :: Software Development :: Libraries',
     'Topic :: Software Development :: Libraries :: Python Modules',
     'Intended Audience :: Developers',
@@ -32,4 +31,4 @@ documentation = 'https://asyncinotify.readthedocs.io/'
 
 [build-system]
 build-backend = "flit_core.buildapi"
-requires = ["flit_core >=3.2,<4", 'wheel']
+requires = ["flit_core >=3.12,<4"]


### PR DESCRIPTION
Flit historically hasn't supported `license.text` unfortunately. However, it recently added full support for PEP 639 license expressions with `v3.12`. Also remove `wheel` as build requirement. Flit doesn't need it.

Metadata diff
```diff
 ...
+License-Expression: MPL-2.0
 ...
-Classifier: License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
 ...
```

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files